### PR TITLE
[WIP] Hacking a solution for CORS

### DIFF
--- a/modules/setting/cors.go
+++ b/modules/setting/cors.go
@@ -13,13 +13,14 @@ import (
 var (
 	// CORSConfig defines CORS settings
 	CORSConfig = struct {
-		Enabled          bool
-		Scheme           string
-		AllowDomain      []string
-		AllowSubdomain   bool
-		Methods          []string
-		MaxAge           time.Duration
-		AllowCredentials bool
+		Enabled             bool
+		Scheme              string
+		AllowDomain         []string
+		AllowSubdomain      bool
+		KitspaceAllowDomain string
+		Methods             []string
+		MaxAge              time.Duration
+		AllowCredentials    bool
 	}{
 		Enabled: false,
 		MaxAge:  10 * time.Minute,

--- a/routers/user/kitspace_auth.go
+++ b/routers/user/kitspace_auth.go
@@ -36,17 +36,6 @@ func KitspaceSignUp(ctx *context.Context, form auth.RegisterForm) {
 	//     "$ref": "#/response/error
 	//   "422":
 	//     "$ref": "#/responses/validationError"
-
-	if len(setting.CORSConfig.AllowDomain) > 0 {
-		allowedDomain := setting.CORSConfig.AllowDomain[0]
-
-		ctx.Resp.Header().Set("Access-Control-Allow-Origin", allowedDomain)
-		ctx.Resp.Header().Set(
-			"Access-Control-Allow-Headers",
-			"Content-Type, Authorization, User-Agent, Cache-Control, pragma")
-		ctx.Resp.Header().Set("Access-Control-Expose-Headers", "Authorization")
-	}
-
 	response := make(map[string]string)
 
 	if len(form.Password) < setting.MinPasswordLength {

--- a/routers/user/kitspace_auth.go
+++ b/routers/user/kitspace_auth.go
@@ -36,6 +36,13 @@ func KitspaceSignUp(ctx *context.Context, form auth.RegisterForm) {
 	//     "$ref": "#/response/error
 	//   "422":
 	//     "$ref": "#/responses/validationError"
+
+	if len(setting.CORSConfig.AllowDomain) > 0 {
+		allowedDomain := setting.CORSConfig.AllowDomain[0]
+
+		ctx.Resp.Header().Set("Access-Control-Allow-Origin", allowedDomain)
+	}
+
 	response := make(map[string]string)
 
 	if len(form.Password) < setting.MinPasswordLength {

--- a/routers/user/kitspace_auth.go
+++ b/routers/user/kitspace_auth.go
@@ -108,8 +108,11 @@ func KitspaceSignUp(ctx *context.Context, form auth.RegisterForm) {
 
 		ctx.JSON(http.StatusOK, response)
 	} else {
-		response := make(map[string]bool)
-		response["IsRegisteredSuccessfully"] = true
+		// make the mock response similar to the response when mailing works
+		response :=  map[string]string{
+			"email": u.Email,
+			"ActiveCodeLives": timeutil.MinutesToFriendly(setting.Service.ActiveCodeLives, ctx.Locale.Language()),
+		}
 
 		ctx.JSON(http.StatusCreated, response)
 	}

--- a/routers/user/kitspace_auth.go
+++ b/routers/user/kitspace_auth.go
@@ -41,7 +41,10 @@ func KitspaceSignUp(ctx *context.Context, form auth.RegisterForm) {
 		allowedDomain := setting.CORSConfig.AllowDomain[0]
 
 		ctx.Resp.Header().Set("Access-Control-Allow-Origin", allowedDomain)
-		ctx.Resp.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, User-Agent")
+		ctx.Resp.Header().Set(
+			"Access-Control-Allow-Headers",
+			"Content-Type, Authorization, User-Agent, Cache-Control, pragma")
+		ctx.Resp.Header().Set("Access-Control-Expose-Headers", "Authorization")
 	}
 
 	response := make(map[string]string)

--- a/routers/user/kitspace_auth.go
+++ b/routers/user/kitspace_auth.go
@@ -41,6 +41,7 @@ func KitspaceSignUp(ctx *context.Context, form auth.RegisterForm) {
 		allowedDomain := setting.CORSConfig.AllowDomain[0]
 
 		ctx.Resp.Header().Set("Access-Control-Allow-Origin", allowedDomain)
+		ctx.Resp.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, User-Agent")
 	}
 
 	response := make(map[string]string)


### PR DESCRIPTION
Trying to solve #6.
seems to work in postman it returns this response:
```
Server nginx/1.17.6
Date Sat, 29 Aug 2020 22:12:34 GMT
Content-Type application/json; charset=UTF-8
Content-Length 53
Connection keep-alive
Access-Control-Allow-Headers
Access-Control-Allow-Methods GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS
Access-Control-Allow-Origin kitspace.test <--------------------------------- it should work!
Access-Control-Max-Age 600
Set-Cookie i_like_gitea=aa442e2ceb86934d; Path=/; domain=.kitspace.test; HttpOnly
X-Csrf-Token 6owCSYoTXOPsslp8U_qJ2hh5SYc6MTU5ODczMDM5OTU5ODgwOTkxMA
X-Frame-Options SAMEORIGIN
```
Wich has the right header `Access-Control-Allow-Origin kitspace.test` yet it doesn't work in the browser.
Does the domain need to be written in this form `http://kitspace.test:3000`? Or it doesn't make a difference?!

With this configuration in the `app.ini` file:
```.ini
ENABLED=true
SCHEME=http
ALLOW_DOMAIN=kitspace.test,staging.kitspace.org,kitspace.org
ALLOW_SUBDOMAIN=true
METHODS=GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS
MAX_AGE=10m
ALLOW_CREDENTIALS=true
```
 