### PR TITLE
Make checking whether user is collaborator in repo w/o token.

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -742,9 +742,10 @@ func Routes() *web.Route {
 						m.Post("/tests", context.RepoRefForAPI, repo.TestHook)
 					})
 				}, reqToken(), reqAdmin(), reqWebhooksEnabled())
+				m.Get("/collaborators/{collaborator}", reqAnyRepoReader(), repo.IsCollaborator)
 				m.Group("/collaborators", func() {
 					m.Get("", reqAnyRepoReader(), repo.ListCollaborators)
-					m.Combo("/{collaborator}").Get(reqAnyRepoReader(), repo.IsCollaborator).
+					m.Combo("/{collaborator}").
 						Put(reqAdmin(), bind(api.AddCollaboratorOption{}), repo.AddCollaborator).
 						Delete(reqAdmin(), repo.DeleteCollaborator)
 				}, reqToken())


### PR DESCRIPTION
- Before the modification, to check whether a user is a collaborator in a repo, required an API token.
- Given that all the repos will be public for kitspace, there's no need for this constrain. Just, constrain it to repo readers.

